### PR TITLE
Feat/lunch

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -31,4 +31,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with unittest
       run: |
-        python -m unittest discover test
+        python -m unittest discover .

--- a/menu.py
+++ b/menu.py
@@ -1,22 +1,62 @@
+import unidecode as unidecode
+
+
 class Menu(object):
-    def __init__(self, meals=None, desserts=None):
-        if meals is None:
-            meals = []
-        self.meals = meals
+    def __init__(self, entrees=None, plats=None, garnitures=None, desserts=None, dessertbar=None):
+        if entrees is None:
+            entrees = []
+        self.entrees = entrees
+
+        if plats is None:
+            plats = []
+        self.plats = plats
+
+        if garnitures is None:
+            garnitures = []
+        self.garnitures = garnitures
 
         if desserts is None:
             desserts = []
         self.desserts = desserts
 
-    def __getitem__(self, item):
-        if item is "meals":
-            return self.meals
-        elif item is "desserts":
+        if dessertbar is None:
+            dessertbar = []
+        self.dessertbar = dessertbar
+
+    def __getitem__(self, key):
+        key = unidecode.unidecode(key).lower().replace("'", "")
+        if key == "entrees":
+            return self.entrees
+        elif key == "plats":
+            return self.plats
+        elif key == "garnitures":
+            return self.garnitures
+        elif key == "desserts":
             return self.desserts
+        elif key == "dessertbar":
+            return self.dessertbar
+        else:
+            print("a Menu has no %s." % key)
+            exit("-1")
 
     def __str__(self):
-        return "Meals: %s, desserts: %s." % (self.meals, self.desserts)
+        sep = ", "
+        return "Starters: %s\nMeals: %s\n Garnitures: %s\n Desserts: %s\n Dessert'Bar: %s." % \
+               (sep.join(self.entrees), sep.join(self.plats), sep.join(self.garnitures), sep.join(self.desserts),
+                sep.join(self.dessertbar))
 
     @property
     def has_food(self):
-        return len(self.meals) or len(self.desserts)
+        return len(self.plats) or len(self.desserts)
+
+
+class Diner(Menu):
+    def __init__(self, plats=None, desserts=None):
+        super().__init__(plats=plats, desserts=desserts)
+
+    def __str__(self):
+        return "Meals: %s, desserts: %s." % (self.plats, self.desserts)
+
+    @property
+    def has_food(self):
+        return len(self.plats) or len(self.desserts)

--- a/menu.py
+++ b/menu.py
@@ -19,10 +19,6 @@ class Menu(object):
             desserts = []
         self.desserts = desserts
 
-        if dessertbar is None:
-            dessertbar = []
-        self.dessertbar = dessertbar
-
     def __getitem__(self, key):
         key = unidecode.unidecode(key).lower().replace("'", "")
         if key == "entrees":
@@ -33,30 +29,32 @@ class Menu(object):
             return self.garnitures
         elif key == "desserts":
             return self.desserts
-        elif key == "dessertbar":
-            return self.dessertbar
+        elif key == "dessertbar":  # DISCUSS: should we separate desserts?
+            return self.desserts
         else:
             print("a Menu has no %s." % key)
             exit("-1")
 
     def __str__(self):
-        sep = ", "
-        return "Starters: %s\nMeals: %s\n Garnitures: %s\n Desserts: %s\n Dessert'Bar: %s." % \
-               (sep.join(self.entrees), sep.join(self.plats), sep.join(self.garnitures), sep.join(self.desserts),
-                sep.join(self.dessertbar))
+        return "Starters: %s\nMeals: %s\n Garnitures: %s\n Desserts: %s\n" % \
+               tuple(["; ".join(it) for it in self.composantes])
 
     @property
     def has_food(self):
-        return len(self.plats) or len(self.desserts)
+        return any(len(it) for it in self.composantes)
+
+    @property
+    def composantes(self):
+        return [self.entrees, self.plats, self.garnitures, self.desserts]
 
 
 class Diner(Menu):
     def __init__(self, plats=None, desserts=None):
         super().__init__(plats=plats, desserts=desserts)
 
+    @property
+    def composantes(self):
+        return [self.plats, self.desserts]
+
     def __str__(self):
         return "Meals: %s, desserts: %s." % (self.plats, self.desserts)
-
-    @property
-    def has_food(self):
-        return len(self.plats) or len(self.desserts)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+unidecode==1.1.1
 beautifulsoup4==4.8.0
 googletrans==2.4.0
 requests==2.22.0

--- a/scraper.py
+++ b/scraper.py
@@ -28,16 +28,17 @@ url_lunch = url_base % id_lunch + "&e=zr"
 
 
 def main():
-    print(get_lunch())
+    print(get_diner())
 
 
 def with_missing_accents(course_name: str):
-    accented_words = ["sauté", "braisé", "grillé", "doré", "flambé", "glacé", "poché", "haché", "caramelisé"]
+    accented_words = ["sauté", "braisé", "grillé", "doré", "flambé", "glacé", "poché", "haché", "caramelisé", "praliné"]
     accented_words += [word + "e" for word in accented_words]
     accented_words += [word + "s" for word in accented_words]
+    accented_words.append("à la")
 
     for word in accented_words:
-        unaccented_word = word.replace("é", "e")
+        unaccented_word = word.replace("é", "e").replace("à", "a")
         match = re.search(r"\b%s\b" % re.escape(unaccented_word), course_name)
         if match is not None:
             course_name = course_name.replace(unaccented_word, word)

--- a/scraper.py
+++ b/scraper.py
@@ -32,7 +32,7 @@ def main():
 
 
 def with_missing_accents(course_name: str):
-    accented_words = ["sauté", "braisé", "grillé", "doré", "flambé", "glacé", "poché", "haché"]
+    accented_words = ["sauté", "braisé", "grillé", "doré", "flambé", "glacé", "poché", "haché", "caramelisé"]
     accented_words += [word + "e" for word in accented_words]
     accented_words += [word + "s" for word in accented_words]
 

--- a/scraper.py
+++ b/scraper.py
@@ -46,6 +46,7 @@ def with_missing_accents(course_name: str):
 
 def get_lunch() -> Menu:
     menu = Menu()
+    translator = googletrans.Translator()
     with requests.Session() as session:
         reset_session(session)
 
@@ -54,10 +55,18 @@ def get_lunch() -> Menu:
         today = soup_lunch.find("div", {'data-is-today': True})
         composantes = today.find_all("div", {"class": "composante-recette"})
         for composante in composantes:
-            composante_name = composante.find("h3", {"class": "recette-title"}).get_text()
+            category = composante.find("h3", {"class": "recette-title"}).get_text()
             items = composante.find_all("li", {"class": "recette-item"})
             for item in items:
-                menu[composante_name].append(item.get_text().strip())
+                dish = item.get_text().strip()
+                try:
+                    spellcheck = did_you_mean(dish)
+                    if spellcheck.lower() != dish.lower():
+                        dish = spellcheck
+                except Exception as e:
+                    print("Spellcheck failed:", e)
+                print("Found available dish:", dish)
+                menu[category].append((dish, translator.translate(dish, src="fr").text, None))
     return menu
 
 

--- a/slackbot.py
+++ b/slackbot.py
@@ -4,8 +4,8 @@ from datetime import date
 
 import slack
 
-from diner import get_dishes
-from menu import Menu
+from scraper import get_diner
+from menu import Diner
 
 
 class SlackBot:
@@ -21,7 +21,7 @@ class SlackBot:
         return self._client
 
     def send_diner(self):
-        text, attachments = SlackBot.make_message(get_dishes())
+        text, attachments = SlackBot.make_message(get_diner())
         self.response = self.client.chat_postMessage(
             channel=os.environ['SLACK_CHANNEL'] if "SLACK_CHANNEL" in os.environ else "#test",
             text=text,
@@ -32,7 +32,7 @@ class SlackBot:
 
     def update_diner(self, channel_id, ts):
         # TODO: Test scheduling an update
-        text, attachments = SlackBot.make_message(*get_dishes())
+        text, attachments = SlackBot.make_message(*get_diner())
         self.client.chat_update(
             channel=channel_id,
             ts=ts,
@@ -47,7 +47,7 @@ class SlackBot:
         There is {number} left, hurry!""".format(fr=fr, en=en, number=number_str)
 
     @staticmethod
-    def make_message(menu: Menu):
+    def make_message(menu: Diner):
         text = "Hi everyone, here's today's _Prêt à dîner_ menu :sir:\n"
 
         if menu.has_food:

--- a/slackbot.py
+++ b/slackbot.py
@@ -51,7 +51,14 @@ class SlackBot:
         )
 
     @staticmethod
-    def format_dish(fr, en, quantity=None):
+    def format_dish(fr: str, en: str, quantity: int = None) -> dict:
+        """Formats the dish as an attachment' field.
+
+        :param fr: Its french name.
+        :param en: Its english name.
+        :param quantity: When specified, how many dishes are available.
+        """
+
         if quantity is not None:
             plural = quantity >= 2
             fr = fr + """

--- a/test.py
+++ b/test.py
@@ -57,7 +57,8 @@ class DinerTestCase(unittest.TestCase):
     """ Tests for the diner scraper. """
 
     def test_with_missing_accents(self):
-        self.assertEqual(with_missing_accents("porc saute"), "porc sauté")
-        self.assertEqual(with_missing_accents("sauterelle"), "sauterelle")
-        self.assertEqual(with_missing_accents("Roti braise"), "Roti braisé")
-        self.assertEqual(with_missing_accents("Roti braise aux patates sautees"), "Roti braisé aux patates sautées")
+        self.assertEqual("porc sauté", with_missing_accents("porc saute"))
+        self.assertEqual("sauterelle", with_missing_accents("sauterelle"))
+        self.assertEqual("Roti braisé", with_missing_accents("Roti braise"))
+        self.assertEqual("Roti braisé aux patates sautées", with_missing_accents("Roti braise aux patates sautees"))
+        self.assertEqual("Steak à la fleur de sel", with_missing_accents("Steak a la fleur de sel"))

--- a/test.py
+++ b/test.py
@@ -40,10 +40,11 @@ class SlackBotTestCase(unittest.TestCase):
 
     def test_format_meal(self):
         (fr, en, q) = mock_meal
-        text = self.bot.format_dish(fr, en, q)
-        self.assertTrue(fr in text, "The text should contain the french dish")
-        self.assertTrue(en in text, "The text should contain the english dish")
-        self.assertTrue(str(q) in text, "The text should contain the quantity")
+        field = self.bot.format_dish(fr, en, q)
+        self.assertTrue(fr in str(field), "The text should contain the french dish")
+        self.assertTrue(en in str(field), "The text should contain the english dish")
+        if q is not None:
+            self.assertTrue(str(q) in str(field), "The text should contain the quantity")
 
     def test_spellcheck_when_translation(self):
         query = "Focacia d'aubergine,légumes grillés et mayonnaise aubergines"

--- a/test.py
+++ b/test.py
@@ -2,7 +2,8 @@ import unittest
 from datetime import date
 
 from didyoumean3.didyoumean import did_you_mean
-from scraper import with_missing_accents
+from diner import with_missing_accents
+from menu import Menu
 from slackbot import SlackBot
 
 mock_meal = ("Aubergines sautées", "sautéed eggplants", 10)
@@ -31,10 +32,10 @@ class SlackBotTestCase(unittest.TestCase):
         self.assertTrue(self.bot.is_canteen_day(friday), "Canteen on fridays")
 
     def test_make_message(self):
-        text, attachments = self.bot.make_message([])
+        text, attachments = self.bot.make_message(Menu())
         self.assertIsNone(attachments, "Empty meals should have no attachments")
 
-        text, attachments = self.bot.make_message([mock_meal])
+        text, attachments = self.bot.make_message(Menu(meals=[mock_meal]))
         self.assertIsNotNone(attachments, "Meals should have some attachments")
 
     def test_format_meal(self):
@@ -57,8 +58,7 @@ class DinerTestCase(unittest.TestCase):
     """ Tests for the diner scraper. """
 
     def test_with_missing_accents(self):
-        self.assertEqual("porc sauté", with_missing_accents("porc saute"))
-        self.assertEqual("sauterelle", with_missing_accents("sauterelle"))
-        self.assertEqual("Roti braisé", with_missing_accents("Roti braise"))
-        self.assertEqual("Roti braisé aux patates sautées", with_missing_accents("Roti braise aux patates sautees"))
-        self.assertEqual("Steak à la fleur de sel", with_missing_accents("Steak a la fleur de sel"))
+        self.assertEqual(with_missing_accents("porc saute"), "porc sauté")
+        self.assertEqual(with_missing_accents("sauterelle"), "sauterelle")
+        self.assertEqual(with_missing_accents("Roti braise"), "Roti braisé")
+        self.assertEqual(with_missing_accents("Roti braise aux patates sautees"), "Roti braisé aux patates sautées")

--- a/test.py
+++ b/test.py
@@ -2,7 +2,7 @@ import unittest
 from datetime import date
 
 from didyoumean3.didyoumean import did_you_mean
-from diner import with_missing_accents
+from scraper import with_missing_accents
 from menu import Menu
 from slackbot import SlackBot
 
@@ -35,7 +35,7 @@ class SlackBotTestCase(unittest.TestCase):
         text, attachments = self.bot.make_message(Menu())
         self.assertIsNone(attachments, "Empty meals should have no attachments")
 
-        text, attachments = self.bot.make_message(Menu(meals=[mock_meal]))
+        text, attachments = self.bot.make_message(Menu(plats=[mock_meal]))
         self.assertIsNotNone(attachments, "Meals should have some attachments")
 
     def test_format_meal(self):

--- a/test.py
+++ b/test.py
@@ -2,7 +2,7 @@ import unittest
 from datetime import date
 
 from didyoumean3.didyoumean import did_you_mean
-from diner import with_missing_accents
+from scraper import with_missing_accents
 from slackbot import SlackBot
 
 mock_meal = ("Aubergines sautées", "sautéed eggplants", 10)


### PR DESCRIPTION
- Make `Diner` extend `Menu`, with more data fields
- Add URLs and scraping logic for regular, non-order menu
- Refactor SlackBot to 
  - always use `attachments`
  - display meals first, then deserts, then starters (if any)
- Improve handling of accents